### PR TITLE
fix report in sphinx

### DIFF
--- a/examples/04_manipulating_images/plot_mask_computation.py
+++ b/examples/04_manipulating_images/plot_mask_computation.py
@@ -52,6 +52,7 @@ masker.fit(miyawaki_filename)
 report = masker.generate_report()
 report
 
+
 ###############################################################################
 # Computing a mask from raw EPI data
 ###############################################################################

--- a/nilearn/reporting/sphinx_report.py
+++ b/nilearn/reporting/sphinx_report.py
@@ -13,7 +13,8 @@ _SCRAPER_TEXT = '''
 
         .. raw:: html
 
-            <iframe class="sg_report" src="{0}"></iframe>
+            <iframe class="sg_report" frameBorder="0" width="None" height="None"
+                srcdoc="{0}"></iframe>
 '''  # noqa: E501
 
 
@@ -33,6 +34,6 @@ class _ReportScraper(object):
             if (isinstance(report, HTMLReport) and
                     gallery_conf['builder_name'] == 'html'):
                 # embed links/iframe
-                data = _SCRAPER_TEXT.format(report.get_iframe())
+                data = _SCRAPER_TEXT.format(report.get_standalone())
                 return data
         return ''

--- a/nilearn/reporting/sphinx_report.py
+++ b/nilearn/reporting/sphinx_report.py
@@ -15,6 +15,7 @@ _SCRAPER_TEXT = '''
 
             <iframe class="sg_report" frameBorder="0" width="None" height="None"
                 srcdoc="{0}"></iframe>
+
 '''  # noqa: E501
 
 
@@ -34,6 +35,10 @@ class _ReportScraper(object):
             if (isinstance(report, HTMLReport) and
                     gallery_conf['builder_name'] == 'html'):
                 # embed links/iframe
-                data = _SCRAPER_TEXT.format(report.get_standalone())
+                report_str = report.get_standalone()
+                data = _SCRAPER_TEXT.format(
+                    ''.join(12 * ' ' + line
+                            for line in report_str.splitlines(True))
+                    + 12 * ' ')
                 return data
         return ''


### PR DESCRIPTION
We cannot use get_iframe because: 1) it escapes HTML, but Sphinx escapes it a second time, 2) it insert the "iframe" a second time.