### PR TITLE
Styling

### DIFF
--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -1694,12 +1694,13 @@ p.sphx-glr-horizontal {
 /* Sphinx-gallery Report embedding */
 div.sg-report {
     padding: 0pt;
+    transform: scale(.95);
 }
 
 div.sg-report iframe {
     display: block;
     border-style: none;
-    transform: scale(.8);
+    transform: scale(.85);
     height: 470px;
     margin-left: -12%; /* Negative because of .8 scaling */
     margin-top: -4%;

--- a/examples/04_manipulating_images/plot_mask_computation.py
+++ b/examples/04_manipulating_images/plot_mask_computation.py
@@ -17,7 +17,6 @@ underlying routine that extract masks from EPI
 
 """
 
-
 from nilearn.input_data import NiftiMasker
 import nilearn.image as image
 from nilearn.plotting import plot_epi, show

--- a/examples/04_manipulating_images/plot_mask_computation.py
+++ b/examples/04_manipulating_images/plot_mask_computation.py
@@ -51,6 +51,7 @@ masker.fit(miyawaki_filename)
 report = masker.generate_report()
 report
 
+
 ###############################################################################
 # Computing a mask from raw EPI data
 ###############################################################################

--- a/examples/04_manipulating_images/plot_mask_computation.py
+++ b/examples/04_manipulating_images/plot_mask_computation.py
@@ -51,7 +51,6 @@ masker.fit(miyawaki_filename)
 report = masker.generate_report()
 report
 
-
 ###############################################################################
 # Computing a mask from raw EPI data
 ###############################################################################

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -211,9 +211,9 @@ class NiftiMasker(BaseMasker, CacheMixin, ReportMixin):
         self.reports = reports
         self._report_description = ('This report shows the input Nifti '
                                     'image overlaid with the outlines of the '
-                                    'mask. We recommend to inspect the report '
-                                    'for the overlap between the mask and its '
-                                    'input image. ')
+                                    'mask (in green). We recommend to inspect '
+                                    'the report for the overlap between the '
+                                    'mask and its input image. ')
         self._overlay_text = ('\n To see the input Nifti image before '
                               'resampling, hover over the displayed image.')
 
@@ -248,8 +248,10 @@ class NiftiMasker(BaseMasker, CacheMixin, ReportMixin):
 
         # create display of retained input mask, image
         # for visual comparison
-        init_display = plotting.plot_img(img, black_bg=False)
-        init_display.add_contours(mask, levels=[.5], colors='r')
+        init_display = plotting.plot_img(img,
+                                         black_bg=False,
+                                         cmap='CMRmap_r')
+        init_display.add_contours(mask, levels=[.5], colors='g')
 
         if self.transform_ is None:
             return [init_display]
@@ -268,8 +270,11 @@ class NiftiMasker(BaseMasker, CacheMixin, ReportMixin):
             else:  # images were not provided to fit
                 resampl_img = resampl_mask
 
-            final_display = plotting.plot_img(resampl_img, black_bg=False)
-            final_display.add_contours(resampl_mask, levels=[.5], colors='r')
+            final_display = plotting.plot_img(resampl_img,
+                                              black_bg=False,
+                                              cmap='CMRmap_r')
+            final_display.add_contours(resampl_mask, levels=[.5],
+                                       colors='g')
 
         return [init_display, final_display]
 

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -60,7 +60,7 @@ End pure-button class definition from pure-min.css
 */
 
 div.nilearn_report {
-    padding-top: 1px;
+    padding-top: 0px;
     border: solid rgb(150, 150, 150);
     border-width: 1pt;
     border-radius: 6pt;
@@ -74,10 +74,14 @@ div.nilearn_report h1 {
     margin-right: 0pt;
     padding-top: 5pt;
     font-size: 1.8em;
+    padding-left: 5pt;
 }
 
 div.nilearn_report h1:first-child {
-    margin-top: 1pt;
+    margin-top: 0pt;
+    background-color: #f5f5f5;
+    border-radius: 6pt 6pt 0pt 0pt;
+    padding-left: 5pt;
 }
 
 div.nilearn_report summary::-webkit-details-marker {
@@ -117,7 +121,7 @@ div.nilearn_report .withtooltip .tooltiptext {
   visibility: hidden;
   max-width: 35em;
   width: 90%;
-  background-color: rgba(24,24,24,0.85);
+  background-color: rgba(24,24,24,0.9);
   color: #fff;
   text-align: left;
   font-size: 12pt;
@@ -126,11 +130,14 @@ div.nilearn_report .withtooltip .tooltiptext {
   padding: 5px;css=resource_path.joinpath('css'),
 
   margin-left: 3pt;
-  margin-top: -5pt;
 
   /* Position the tooltip text - see examples below! */
   position: absolute;
   z-index: 1;
+
+  width: 99%;
+  left: 2pt;
+  top: 133%;
 }
 
 /* Show the tooltip text when you mouse over the tooltip container */

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -64,6 +64,7 @@ div.nilearn_report {
     border: solid rgb(150, 150, 150);
     border-width: 1pt;
     border-radius: 6pt;
+    overflow: hidden;  /* Needed to avoid scrolling in jupyter :( */
 }
 
 /* Isolate us a bit from the styles specified by other stylesheets */

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -69,7 +69,6 @@ div.nilearn_report {
 /* Isolate us a bit from the styles specified by other stylesheets */
 div.nilearn_report h1 {
     text-align: left;
-    padding-top: 15px;
     margin-left: 0pt;
     margin-right: 0pt;
     padding-top: 5pt;

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -70,6 +70,8 @@ div.nilearn_report h1 {
     margin-left: 0pt;
     margin-right: 0pt;
     margin-top: 5pt;
+    padding-top: 5pt;
+    font-size: 1.8em;
 }
 
 div.nilearn_report summary::-webkit-details-marker {

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -67,6 +67,9 @@ div.nilearn_report {
 div.nilearn_report h1 {
     text-align: left;
     padding-top: 15px;
+    margin-left: 0pt;
+    margin-right: 0pt;
+    margin-top: 5pt;
 }
 
 div.nilearn_report summary::-webkit-details-marker {

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -60,11 +60,10 @@ End pure-button class definition from pure-min.css
 */
 
 div.nilearn_report {
-    padding-top: 5px;
+    padding-top: 1px;
     border: solid rgb(150, 150, 150);
     border-width: 1pt;
     border-radius: 6pt;
-    overflow-x: auto;
 }
 
 /* Isolate us a bit from the styles specified by other stylesheets */
@@ -73,9 +72,12 @@ div.nilearn_report h1 {
     padding-top: 15px;
     margin-left: 0pt;
     margin-right: 0pt;
-    margin-top: 3pt;
     padding-top: 5pt;
     font-size: 1.8em;
+}
+
+div.nilearn_report h1:first-child {
+    margin-top: 1pt;
 }
 
 div.nilearn_report summary::-webkit-details-marker {
@@ -98,6 +100,10 @@ div.nilearn_report thead th {
 
 div.nilearn_report tbody tr:nth-child(even) {
    background-color: #ddd;
+}
+
+div.nilearn_report details {
+    overflow-x: scroll;
 }
 
 /* Tooltip container */

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -96,6 +96,7 @@ div.nilearn_report table {
     max-width: 100%;
     border-collapse: collapse;
     margin:50px auto;
+    float: right;
 }
 
 div.nilearn_report thead th {
@@ -107,7 +108,7 @@ div.nilearn_report tbody tr:nth-child(even) {
 }
 
 div.nilearn_report details {
-    overflow-x: scroll;
+    overflow-x: visible;
 }
 
 /* Tooltip container */
@@ -149,6 +150,7 @@ div.nilearn_report .image {
   position: relative;
   height: auto;
   width: 100%;
+  z-index: -1;
 }
 
 div.nilearn_report .image .overlay {

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -61,6 +61,10 @@ End pure-button class definition from pure-min.css
 
 div.nilearn_report {
     padding-top: 5px;
+    border: solid rgb(150, 150, 150);
+    border-width: 1pt;
+    border-radius: 6pt;
+    overflow-x: auto;
 }
 
 /* Isolate us a bit from the styles specified by other stylesheets */
@@ -69,7 +73,7 @@ div.nilearn_report h1 {
     padding-top: 15px;
     margin-left: 0pt;
     margin-right: 0pt;
-    margin-top: 5pt;
+    margin-top: 3pt;
     padding-top: 5pt;
     font-size: 1.8em;
 }


### PR DESCRIPTION
The two first commits are, I believe, uncontroversial. They are pretty much about making sure that the embedded reports do not inherit too much styling from the outside.

The last two add a border to the report. I find it more readable, because I find that it makes it clear that the content goes together as a unit.

Rendering:

* In the online documentation:
![tmp1](https://user-images.githubusercontent.com/208217/64220321-f6a5fb80-ce96-11e9-85cc-32b86341f5b1.png)

* In jupyter notebook
![tmp2](https://user-images.githubusercontent.com/208217/64220333-002f6380-ce97-11e9-8544-7cc5c05f2b7e.png)


